### PR TITLE
hardcode lounge version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "npm": ">= 1.0.0"
   },
   "dependencies": {
-    "thelounge" : "next",
+    "thelounge" : "2.0.1",
     "irc-framework" : "https://github.com/pacbard/irc-framework/archive/2.5.0.tar.gz"
   },
   "devDependencies": {},


### PR DESCRIPTION
When creating the OpenShift app it fails because npm can't resolve `next` as a version. This gets fixed when hardcoding a version (the latest in this case is `2.0.1`).
